### PR TITLE
rebuild against llvm17 (more exactly, naming of ld64 has changed)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: False

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
   version: {{ version }}{{ version_suffix }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not osx]
 
 outputs:
@@ -30,8 +30,8 @@ outputs:
         - gfortran_impl_{{ cross_target_platform }} =={{ version }}{{ version_suffix }}
       run:
         - clang
-        - ld64_{{ cross_target_platform }}
-        - cctools_{{ cross_target_platform }}
+        - ld64
+        - cctools
         - gfortran_impl_{{ cross_target_platform }} =={{ version }}{{ version_suffix }}
         - gfortran_impl_{{ target_platform }}
         - libgfortran-devel_{{ cross_target_platform }} =={{ version }}{{ version_suffix }}


### PR DESCRIPTION
rebuild against llvm17 (more exactly, naming of ld64 has changed)

rebuilding 11.2 since this is the version we have been using since forever.