### PR TITLE
gfortran_osx-64 14.3.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/gfortran_impl_osx-64-feedstock/pr8/4b17e8d

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,15 +1,4 @@
-macos_machine:
-  - x86_64-apple-darwin13.4.0   # [osx and x86_64]
-  - arm64-apple-darwin20.0.0    # [osx and arm64]
-  - dummy  # [not osx]
 cross_target_platform:
-  - osx-64       # [osx and x86_64]
   - osx-arm64    # [osx and arm64]
-  - dummy  # [not osx]
 gfortran_version:
-  - "11.3.0"    # [osx]
-  - "0.0.0"  # [not osx]
-MACOSX_DEPLOYMENT_TARGET:
-  - 11.1        # [arm64]
-  - 10.10       # [not arm64]
-  - 0.0         # [not osx]
+  - "14.3.0"    # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% if gfortran_version is not defined %}
-{% set gfortran_version = "11.3.0" %}
+{% set gfortran_version = "14.3.0" %}
 {% endif %}
 {% set version = gfortran_version %}
 {% set libgfortran_major_version = "5" %}
@@ -25,7 +25,6 @@ outputs:
         - gfortran_{{ target_platform }}
     requirements:
       build:
-        - gfortran_{{ target_platform }}   # [target_platform != cross_target_platform]
       host:
         - gfortran_impl_{{ cross_target_platform }} =={{ version }}{{ version_suffix }}
       run:
@@ -36,8 +35,8 @@ outputs:
         - gfortran_impl_{{ target_platform }}
         - libgfortran-devel_{{ cross_target_platform }} =={{ version }}{{ version_suffix }}
         - libgfortran-devel_{{ target_platform }}         # [osx]
-        - libgfortran {{ libgfortran_major_version }}.*                                   # [target_platform == cross_target_platform]
-        - libgfortran{{ libgfortran_major_version }} >={{ version }}{{ version_suffix }}  # [target_platform == cross_target_platform]
+        - libgfortran {{ libgfortran_major_version }}.*
+        - libgfortran{{ libgfortran_major_version }} >={{ version }}{{ version_suffix }}
         - clang_{{ cross_target_platform }}
     test:
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,7 @@ about:
   license_family: GPL
   license_file: COPYING3
   summary: Fortran compiler from the GNU Compiler Collection
+  description: Fortran compiler from the GNU Compiler Collection
   dev_url: https://gcc.gnu.org/git/?p=gcc.git;a=tree
   doc_url: https://gcc.gnu.org/onlinedocs/
 


### PR DESCRIPTION
gfortran_osx-64 14.3.0 

**Destination channel:** Defaults

### Links

- [PKG-10380]
- dev_url:        https://gcc.gnu.org/git/?p=gcc.git;a=tree
- conda_forge:    https://github.com/conda-forge/gfortran_osx-64-feedstock
- pypi:           https://pypi.org/project/gfortran_osx-64/14.3.0
- pypi inspector: https://inspector.pypi.io/project/gfortran_osx-64/14.3.0

### Explanation of changes:

- new version number
- stripped out cross-platform tests -- although the `cross_platform_target` variable remains.  That could go if we want.


[PKG-10380]: https://anaconda.atlassian.net/browse/PKG-10380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ