### PR TITLE
gfortran_osx-64 14.3.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/gfortran_impl_osx-64-feedstock/pr9/50724e1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/gfortran_impl_osx-64-feedstock/pr9/8cc59af

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/pbp/fs/gfortran_impl_osx-64-feedstock/pr9/8cc59af
+  - https://staging.continuum.io/pbp/fs/gfortran_impl_osx-64-feedstock/pr9/50724e1

--- a/recipe/build_gfortran.sh
+++ b/recipe/build_gfortran.sh
@@ -39,14 +39,3 @@ find . -name "*activate*.sh" -exec sed -i.bak "s|@CONDA_BUILD_CROSS_COMPILATION@
 mkdir -p ${PREFIX}/etc/conda/{de,}activate.d
 cp "${SRC_DIR}"/activate-gfortran.sh ${PREFIX}/etc/conda/activate.d/activate-${PKG_NAME}.sh
 cp "${SRC_DIR}"/deactivate-gfortran.sh ${PREFIX}/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh
-
-ln -s ${PREFIX}/bin/${CHOST}-ar       $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/ar
-ln -s ${PREFIX}/bin/${CHOST}-as       $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/as
-ln -s ${PREFIX}/bin/clang             $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/clang
-ln -s ${PREFIX}/bin/${CHOST}-nm       $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/nm
-ln -s ${PREFIX}/bin/${CHOST}-ranlib   $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/ranlib
-ln -s ${PREFIX}/bin/${CHOST}-strip    $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/strip
-ln -s ${PREFIX}/bin/${CHOST}-ld       $PREFIX/lib/gcc/${CHOST}/${gfortran_version}/ld
-
-# remove this symlink so that conda-build doesn't follow symlinks
-rm -f ${PREFIX}/bin/clang

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,16 +1,10 @@
 macos_machine:
-  - x86_64-apple-darwin13.4.0
   - arm64-apple-darwin20.0.0
 cross_target_platform:
-  - osx-64
   - osx-arm64
 gfortran_version:
-  - 15.1.0
+  - 15.2.0
   - 14.3.0
-  - 13.4.0
 zip_keys:
   - - cross_target_platform
     - macos_machine
-# only for linux; osx is covered by c_stdlib_version from global pinning
-MACOSX_DEPLOYMENT_TARGET:   # [not osx]
-  - 10.9                    # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ outputs:
       host:
         - gfortran_impl_{{ cross_target_platform }} =={{ version }}
         - clang_{{ target_platform }}    # [osx]
-        - gcc_{{ target_platform }}      # [linux]
       run:
         - clang
         - ld64     # _{{ cross_target_platform }}
@@ -53,7 +52,7 @@ outputs:
     script: install_symlink.sh
     build:
       skip: True  # [cross_target_platform != target_platform]
-      skip: True  # [win]
+      skip: True  # [not osx]
     requirements:
       host:
         - gfortran_{{ cross_target_platform }} =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ outputs:
         - gcc_{{ target_platform }}      # [linux]
       run:
         - clang
-        - ld64_{{ cross_target_platform }}
-        - cctools_{{ cross_target_platform }}
+        - ld64     # _{{ cross_target_platform }}
+        - cctools  # _{{ cross_target_platform }}
         - gfortran_impl_{{ cross_target_platform }} =={{ version }}
         - gfortran_impl_{{ target_platform }}
         - libgfortran-devel_{{ cross_target_platform }} =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,10 @@ outputs:
         - clang_{{ target_platform }}    # [osx]
       run:
         - clang
-        - ld64     # _{{ cross_target_platform }}
-        - cctools  # _{{ cross_target_platform }}
+        # our ld64_{{ cross_target_platform }} and cctools_{{ cross_target_platform }}
+        # are out of date
+        - ld64
+        - cctools
         - gfortran_impl_{{ cross_target_platform }} =={{ version }}
         - gfortran_impl_{{ target_platform }}
         - libgfortran-devel_{{ cross_target_platform }} =={{ version }}
@@ -58,6 +60,8 @@ outputs:
         - gfortran_{{ cross_target_platform }} =={{ version }}
       run:
         - gfortran_{{ cross_target_platform }} =={{ version }}
+        # our ld64_{{ cross_target_platform }} and cctools_{{ cross_target_platform }}
+        # are out of date
         - ld64
         - cctools
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 build:
   number: 0
-  skip: True  # [win]
+  skip: True  # [not osx]
 
 outputs:
   - name: gfortran_{{ cross_target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,10 +67,13 @@ outputs:
         - gfortran --help
 
 about:
-  home: http://gcc.gnu.org/
+  home: https://gcc.gnu.org/
   license: GPL-3.0-or-later WITH GCC-exception-3.1
   license_file: COPYING3
   summary: Fortran compiler from the GNU Compiler Collection
+  description: Fortran compiler from the GNU Compiler Collection
+  doc_url: https://gcc.gnu.org/onlinedocs/
+  dev_url: https://gcc.gnu.org/git/gcc.git
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
gfortran_osx-64 14.3.0 & 15.2.0

**Destination channel:** Defaults

### Links

- [PKG-10380]
- dev_url:        https://gcc.gnu.org/git/?p=gcc.git;a=tree
- conda_forge:    https://github.com/conda-forge/gfortran_osx-64-feedstock
- pypi:           https://pypi.org/project/gfortran_osx-64/14.3.0
- pypi inspector: https://inspector.pypi.io/project/gfortran_osx-64/14.3.0

### Explanation of changes:

- resync with conda-forge
  - new version numbers -- we are on 15.2.0 (CF was 15.1.0) and 14.3.0 -- no 13.4.0
  - in `cbc.yaml`:
    - limit to `osx-arm64`
    - remove `MACOS_DEPLOYMENT_TARGET` -- in `aggregate`'s `cbc.yaml`
  - in `meta.yaml`
    - limit to `osx`
    - use our `ld64` and `cctools` as our `*_osx-arm64` variants are using old llvm
  - in `build_gfortran.sh` removed the symlinks code as this has previously been moved to the `gfortran_impl_osx-64` (in https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/pull/93)

### Testing

For both 14.3.0 and 15.2.0 compilers -- noting that 15.2.0 libraries will get used.

- `openblas` is required for
- `scipy`
- `go`

Note, however:

- `mpich` -- I consistently get the same `OFI poll failed (default nic=utun0: Input/output error)` during testing for all three compilers: 11.2.0, 14.3.0, 15.2.0
- `hdf5` replacing the explicit dependency on 11.2.0 with `{{ gfortran_compiler_version }}` means it builds and runs the tests for 14.3.0 and 15.2.0 (but the `h5cc` test doesn't find `clang`[1]) but  but 11.2.0 fails with:

```
-- Verifying Fortran/C Compiler Compatibility - Failed
-- Configuring incomplete, errors occurred!
```


[PKG-10380]: https://anaconda.atlassian.net/browse/PKG-10380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[1] The `h5cc` compiler doesn't find `clang` because the `h5cc` script has the `$BUILD_PREFIX` in it, not the `$PREFIX`:

```
+ h5cc h5_cmprss.c -o h5_cmprss
$PREFIX/bin/h5cc: line 81: .../conda-bld/hdf5_1763984792530/_build_env/bin/arm64-apple-darwin20.0.0-clang: No such file or directory
```

